### PR TITLE
Avoid interference from text body parser

### DIFF
--- a/express/src/auth.ts
+++ b/express/src/auth.ts
@@ -139,16 +139,14 @@ console.log({isConfigured,configuration})
         }
         next()
     })
-
-    r.use(text()); // for parsing text/plain
     
-    r.post(configuration.apiRoute, async (req: Request, res: Response ) => {
+    r.post(configuration.apiRoute, text(), async (req: Request, res: Response ) => {
         const helloReq = convertToHelloRequest(req,res)
         const helloRes = convertToHelloResponse(res)
         await router(helloReq, helloRes)   
     })
 
-    r.get(configuration.apiRoute, async (req: Request, res: Response ) => {
+    r.get(configuration.apiRoute, text(), async (req: Request, res: Response ) => {
         const helloReq = convertToHelloRequest(req,res)
         const helloRes = convertToHelloResponse(res)
         await router(helloReq, helloRes)   


### PR DESCRIPTION
This this router is often added at the root of the express server, the `text()` body parser would be executed for every other route. In my codebase, I have routes that require the body to be unprocessed. This change should add the `text()` body parser to the relevant routes, without interfering with the rest of the express app.