### PR TITLE
chore: bump GitHub Actions to Node-24-compatible majors

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -19,10 +19,10 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
     test:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: 'npm'
@@ -30,8 +30,8 @@ jobs:
             contents: read
             id-token: write
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/checkout@v6
+            - uses: actions/setup-node@v6
               with:
                   node-version: 24
                   cache: 'npm'


### PR DESCRIPTION
GitHub forces JS actions to Node 24 on 2026-06-16 and removes Node 20 on 2026-09-16. This standardizes the GitHub-maintained actions up to their latest majors.

Bumps:
- actions/checkout v4 -> v6 (ci.yml, canary.yml, release.yml)
- actions/setup-node v4 -> v6 (ci.yml, canary.yml, release.yml)

No third-party actions, no artifact/cache/setup-go actions present. `node-version` is explicitly pinned at each setup-node step (22/24), so the setup-node major bump has no default-version risk.

Note: actionlint reports a pre-existing SC2162 shellcheck warning in the release.yml publish script (`read` without `-r`), unrelated to this bump and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
