### PR TITLE
ci: make lint pass, so tests actually run

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 node_modules
 dist
+dist-test
 archive*
+.svelte-kit
+.claude

--- a/email-verification/src/__tests__/issuance-token.test.ts
+++ b/email-verification/src/__tests__/issuance-token.test.ts
@@ -144,7 +144,6 @@ describe('IssuanceToken Functions', () => {
         })
 
         it('should throw error for missing JWK algorithm', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { alg: _alg, ...keyWithoutAlg } = rsaPrivateKey
 
             await expect(
@@ -153,7 +152,6 @@ describe('IssuanceToken Functions', () => {
         })
 
         it('should throw error for missing JWK kid', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { kid: _kid, ...keyWithoutKid } = rsaPrivateKey
 
             await expect(
@@ -295,7 +293,6 @@ describe('IssuanceToken Functions', () => {
         })
 
         it('should throw error for missing cnf.jwk claim', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { cnf: _cnf, ...payloadWithoutCnf } = testPayload
 
             const header = {

--- a/email-verification/src/__tests__/presentation-token.test.ts
+++ b/email-verification/src/__tests__/presentation-token.test.ts
@@ -233,7 +233,6 @@ describe('PresentationToken Functions', () => {
         })
 
         it('should throw error for invalid JWK', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { alg: _alg, ...invalidKey } = rsaBrowserKey
 
             const issuanceTokenPayload: IssuanceTokenPayload = {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,7 +8,14 @@ export default [
     ...tseslint.configs.recommended,
     prettierConfig, // Disable ESLint rules that conflict with Prettier
     {
-        ignores: ['**/dist', '**/dist-test', '**/node_modules', 'archive*/'],
+        ignores: [
+            '**/dist',
+            '**/dist-test',
+            '**/node_modules',
+            '**/.svelte-kit',
+            'archive*/',
+            '.claude/',
+        ],
     },
     {
         languageOptions: {
@@ -28,6 +35,18 @@ export default [
 
             '@typescript-eslint/ban-ts-comment': 'off', // TBD: allow @ts-ignore comments
             '@typescript-eslint/no-empty-object-type': 'off', // TBD: Auth | {} allow empty object
+
+            // Destructuring to omit members -- stripping private fields from a
+            // JWK, for example -- names the fields it is discarding. They are
+            // not unused; naming them is how the omission works.
+            '@typescript-eslint/no-unused-vars': [
+                'error',
+                {
+                    ignoreRestSiblings: true,
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                },
+            ],
         },
     },
 ]

--- a/httpsig/src/utils/crypto.ts
+++ b/httpsig/src/utils/crypto.ts
@@ -249,7 +249,6 @@ export async function importPublicKey(jwk: JsonWebKey): Promise<CryptoKey> {
  * Extract public JWK from private JWK
  */
 export function getPublicJwk(privateJwk: JsonWebKey): JsonWebKey {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { d, p, q, dp, dq, qi, ...publicJwk } = privateJwk
     return publicJwk
 }

--- a/httpsig/tests/test-jkt-jwt.ts
+++ b/httpsig/tests/test-jkt-jwt.ts
@@ -5,7 +5,7 @@
 import { test } from 'node:test'
 import assert from 'node:assert'
 import { fetch, verify } from '../src/index.js'
-import { base64urlEncode, base64urlDecode } from '../src/utils/base64.js'
+import { base64urlEncode } from '../src/utils/base64.js'
 import { calculateThumbprint } from '../src/utils/thumbprint.js'
 
 /**

--- a/web-identity/src/__tests__/issuance-token.test.ts
+++ b/web-identity/src/__tests__/issuance-token.test.ts
@@ -144,7 +144,6 @@ describe('IssuanceToken Functions', () => {
         })
 
         it('should throw error for missing JWK algorithm', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { alg: _alg, ...keyWithoutAlg } = rsaPrivateKey
 
             await expect(
@@ -153,7 +152,6 @@ describe('IssuanceToken Functions', () => {
         })
 
         it('should throw error for missing JWK kid', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { kid: _kid, ...keyWithoutKid } = rsaPrivateKey
 
             await expect(
@@ -295,7 +293,6 @@ describe('IssuanceToken Functions', () => {
         })
 
         it('should throw error for missing cnf.jwk claim', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { cnf: _cnf, ...payloadWithoutCnf } = testPayload
 
             const header = {

--- a/web-identity/src/__tests__/presentation-token.test.ts
+++ b/web-identity/src/__tests__/presentation-token.test.ts
@@ -230,7 +230,6 @@ describe('PresentationToken Functions', () => {
         })
 
         it('should throw error for invalid JWK', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { alg: _alg, ...invalidKey } = rsaBrowserKey
 
             const issuanceTokenPayload: IssuanceTokenPayload = {

--- a/web-identity/src/__tests__/request-token.test.ts
+++ b/web-identity/src/__tests__/request-token.test.ts
@@ -80,7 +80,6 @@ describe('RequestToken Functions', () => {
         })
 
         it('should throw error for missing JWK algorithm', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { alg: _alg, ...keyWithoutAlg } = rsaKey
 
             await expect(
@@ -89,7 +88,6 @@ describe('RequestToken Functions', () => {
         })
 
         it('should throw error for missing JWK kid', async () => {
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { kid: _kid, ...keyWithoutKid } = rsaKey
 
             await expect(


### PR DESCRIPTION
CI has failed on every branch since February. Because `npm run lint` runs before `lerna run test`, **the test suite has not executed on a pull request in months** — PR #65 merged in an `UNSTABLE` state for this reason. The publish workflow tests separately, so releases stayed gated; pull requests did not.

## Two causes

**Prettier had no ignore for generated output.** `.prettierignore` listed `node_modules`, `dist`, `archive*`; the eslint config additionally ignored `dist-test`. The two lists disagreed, so prettier checked `dist-test` and `.svelte-kit` — which only exist after a build — and failed on 106 files nobody wrote. Aligned them and added `.svelte-kit` and `.claude`.

**Eslint reported 14 errors.** Seven from `.claude/worktrees`, a local directory it should never have read. The other seven were this idiom:

```ts
const { d, p, q, dp, dq, qi, ...publicJwk } = privateJwk
```

Naming the discarded fields *is* how the omission works — they are not unused. Set `ignoreRestSiblings` instead of scattering `eslint-disable` comments, which also retired the ones already in the tree.

## One thing worth revisiting separately

Removing those disables reformatted the files they were in, which prettier then flagged. That is an ordering problem in the script:

```
prettier --check . && eslint --fix
```

The formatter check runs *before* the fixer, so anything eslint rewrites is never checked, and the failure surfaces on someone else’s next run. I left the script alone and committed the formatted result rather than change the lint contract in a fix PR — but `--fix` in CI mutates a checkout nothing will commit, so `eslint` without `--fix` is probably what CI wants.

## Verified

`prettier --check` clean, `eslint` clean, `npm run lint` exits 0, and httpsig (145), better-auth and email-verification all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXExbWHeem2SNb7tZ2LGnc