### PR TITLE
httpsig 2.2.0: content-digest auto-coverage and verification enforcement

### DIFF
--- a/httpsig/README.md
+++ b/httpsig/README.md
@@ -119,6 +119,15 @@ interface HttpSigFetchOptions extends RequestInit {
     label?: string // Signature label (default: 'sig')
     components?: string[] // Override default components
 
+    // Content-Digest coverage for requests with a body (default: 'auto')
+    // 'auto'    - cover content-digest when the body's exact bytes are
+    //             available to hash (string, Uint8Array, ArrayBuffer, Buffer);
+    //             streaming bodies (ReadableStream, FormData, Blob) are
+    //             signed without it
+    // 'require' - like 'auto', but throw on a body that cannot be digested
+    // 'omit'    - never auto-append content-digest
+    contentDigest?: 'auto' | 'require' | 'omit'
+
     // Testing mode
     dryRun?: boolean // Return headers without fetching (still returns Promise)
 }
@@ -258,9 +267,13 @@ interface VerifyOptions {
     // JWKS caching
     jwksCacheTtl?: number // JWKS cache TTL in ms (default: 3600000)
 
-    // AAuth profile enforcement
-    strictAAuth?: boolean // Enforce AAuth profile requirements (default: true)
-    // When true, requires signature-key in covered components
+    // Algorithms this verifier accepts (default: SUPPORTED_ALGORITHMS)
+    supportedAlgorithms?: SignatureAlgorithm[]
+
+    // AAuth HTTPSig profile (Section 10.3) enforcement: when true, a request
+    // with a body fails verification unless the signature covers
+    // content-digest and the digest validates against the body
+    requireContentDigest?: boolean
 }
 ```
 
@@ -512,13 +525,22 @@ Signature-Input: sig=("@method" "@authority" "@path" "signature-key");created=17
 Signature-Input: sig=("@method" "@authority" "@path" "content-type" "signature-key");created=1730217600
 ```
 
-**Optional: Content-Digest**
+**Content-Digest (automatic since 2.2.0)**
 
-If you want body integrity verification, you can add `content-digest` to your components list. When included, the `content-digest` header is computed as:
+Per the AAuth HTTPSig profile (Section 10.3), a request carrying a body to a
+PS or AS endpoint MUST also cover `content-digest` (RFC 9530). `fetch()`
+appends `content-digest` to the covered components automatically whenever the
+body's exact bytes are available to hash — a string, Uint8Array, ArrayBuffer,
+or Buffer. A body serialized by the fetch implementation (ReadableStream,
+FormData, Blob) is signed without it; pass `contentDigest: 'require'` to
+throw instead, or `contentDigest: 'omit'` to never auto-append. The header is
+computed as:
 
 ```
 Content-Digest: sha-256=:BASE64(SHA256(body)):
 ```
+
+A verifier enforces coverage with `requireContentDigest: true`.
 
 ### Overriding Default Components
 
@@ -544,10 +566,10 @@ import {
 // ['@method', '@authority', '@path', 'content-type', 'signature-key']
 ```
 
-**Example - Adding content-digest for body integrity:**
+**Example - Custom components:**
 
 ```typescript
-// Add content-digest if you need body integrity verification
+// Add the date header to the covered components
 await fetch('https://api.example.com/data', {
     method: 'POST',
     headers: {
@@ -563,8 +585,8 @@ await fetch('https://api.example.com/data', {
         '@path',
         'date', // Include date header
         'content-type',
-        'content-digest', // Add for body integrity
         'signature-key',
+        // content-digest is appended automatically for a digestible body
     ],
 })
 ```

--- a/httpsig/package.json
+++ b/httpsig/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hellocoop/httpsig",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "description": "HTTP Message Signatures (RFC 9421) with Signature-Key header support",
     "repository": {
         "type": "git",

--- a/httpsig/src/fetch.ts
+++ b/httpsig/src/fetch.ts
@@ -62,6 +62,21 @@ function getContentTypeFromBody(body: any): string | null {
 }
 
 /**
+ * Whether generateContentDigest can hash this body: the digest must be
+ * computed over the exact bytes that go on the wire, so only bodies whose
+ * bytes are available here qualify. A ReadableStream, FormData, or Blob is
+ * serialized by the fetch implementation, not by us.
+ */
+function isDigestibleBody(body: any): boolean {
+    return (
+        typeof body === 'string' ||
+        body instanceof Uint8Array ||
+        body instanceof ArrayBuffer ||
+        Buffer.isBuffer(body)
+    )
+}
+
+/**
  * Validate component names
  */
 function validateComponents(components: string[], headers: Headers): void {
@@ -122,6 +137,7 @@ export async function fetch(
         signatureKey,
         label = 'sig',
         components: customComponents,
+        contentDigest = 'auto',
         dryRun = false,
         returnSent = false,
         method = 'GET',
@@ -173,6 +189,25 @@ export async function fetch(
         components = hasBody
             ? [...DEFAULT_COMPONENTS_BODY]
             : [...DEFAULT_COMPONENTS_GET]
+    }
+
+    // Per AAuth Section 10.3, a request carrying a body MUST cover
+    // content-digest. Cover it whenever the body's exact bytes are available
+    // to hash. 'require' refuses to sign a body that cannot be digested,
+    // rather than sending a request the server must reject; 'omit' restores
+    // the pre-2.2 behavior for callers that opt out.
+    if (body !== undefined && body !== null && contentDigest !== 'omit') {
+        const digestible = isDigestibleBody(body)
+        if (!digestible && contentDigest === 'require') {
+            throw new Error(
+                'contentDigest is "require" but the body cannot be digested: ' +
+                    'only string, Uint8Array, ArrayBuffer, and Buffer bodies ' +
+                    'have their exact bytes available to hash',
+            )
+        }
+        if (digestible && !components.includes('content-digest')) {
+            components.push('content-digest')
+        }
     }
 
     const componentValues = new Map<string, string>()

--- a/httpsig/src/types.ts
+++ b/httpsig/src/types.ts
@@ -66,6 +66,24 @@ export interface HttpSigFetchOptions extends RequestInit {
     label?: string // Signature label (default: 'sig')
     components?: string[] // Override default components
 
+    /**
+     * Content-Digest coverage for requests with a body, per the AAuth HTTPSig
+     * profile (Section 10.3): a request carrying a body to a PS or AS
+     * endpoint MUST cover `content-digest` (RFC 9530).
+     *
+     * - `'auto'` (default): cover `content-digest` when the body's exact
+     *   bytes are available to hash here -- a string, Uint8Array,
+     *   ArrayBuffer, or Buffer. A body whose bytes are produced by the fetch
+     *   implementation (ReadableStream, FormData, Blob) is signed without it.
+     * - `'require'`: like `'auto'`, but throw on a body that cannot be
+     *   digested instead of silently dropping the component. PS and AS
+     *   callers use this: refusing to sign beats sending a request the
+     *   server must reject.
+     * - `'omit'`: never auto-append `content-digest` (the pre-2.2 behavior).
+     *   It is still covered when listed explicitly in `components`.
+     */
+    contentDigest?: 'auto' | 'require' | 'omit'
+
     // Testing mode
     dryRun?: boolean // Return headers without fetching (still returns Promise)
 
@@ -122,6 +140,17 @@ export interface VerifyOptions {
      * for example to accept Ed25519 only, or to refuse RSASSA-PKCS1-v1_5.
      */
     supportedAlgorithms?: SignatureAlgorithm[]
+
+    /**
+     * When true, a request with a body fails verification unless the
+     * signature covers `content-digest` (and the digest validates against
+     * the body). This is how a PS or AS enforces the AAuth HTTPSig profile
+     * (Section 10.3) -- without it the digest is validated only when the
+     * signer chose to cover it, which enforces nothing. Resources are exempt
+     * from the profile rule and declare their needs via
+     * `additional_signature_components` in resource metadata.
+     */
+    requireContentDigest?: boolean
 }
 
 // Note: the strictAAuth option was removed in 2.0. Covering `signature-key` is

--- a/httpsig/src/utils/signature.ts
+++ b/httpsig/src/utils/signature.ts
@@ -221,8 +221,15 @@ export async function generateContentDigest(body: BodyInit): Promise<string> {
     } else if (Buffer.isBuffer(body)) {
         bytes = new Uint8Array(body)
     } else {
-        // For other types (ReadableStream, etc.), convert to string
-        bytes = new TextEncoder().encode(String(body))
+        // Refuse other types (ReadableStream, FormData, Blob, ...). Falling
+        // through to String(body) here produced a valid signature over the
+        // SHA-256 of literal text like "[object ReadableStream]" -- bytes
+        // that never go on the wire and that no verifier can reproduce.
+        throw new Error(
+            `Cannot generate content-digest for body type: ${
+                (body as any)?.constructor?.name ?? typeof body
+            }`,
+        )
     }
 
     const hash = await sha256(bytes)

--- a/httpsig/src/verify.ts
+++ b/httpsig/src/verify.ts
@@ -423,6 +423,7 @@ export async function verify(
         maxClockSkew = 60,
         jwksCacheTtl = 3600000, // 1 hour
         supportedAlgorithms,
+        requireContentDigest = false,
     } = options
 
     // The set this verifier accepts. Reported in Accept-Signature-Alg on an
@@ -600,6 +601,29 @@ export async function verify(
         componentValues.set('@request-target', `${request.path}${queryString}`)
         componentValues.set('@path', request.path)
         componentValues.set('@query', request.query || '')
+
+        // Enforce the AAuth HTTPSig profile (Section 10.3): a request with a
+        // body must cover content-digest. Opt-in, because only a PS or AS is
+        // bound by the profile rule -- and without this check the digest
+        // below is validated only when the signer chose to cover it, which
+        // enforces nothing.
+        if (
+            requireContentDigest &&
+            request.body !== undefined &&
+            !components.includes('content-digest')
+        ) {
+            throw invalidInput(
+                'content-digest must be a covered component on a request with a body',
+                [
+                    '@method',
+                    '@authority',
+                    '@path',
+                    'content-digest',
+                    'content-type',
+                    'signature-key',
+                ],
+            )
+        }
 
         // Validate content-digest if body is present
         if (

--- a/httpsig/tests/test-content-digest.ts
+++ b/httpsig/tests/test-content-digest.ts
@@ -1,0 +1,463 @@
+/**
+ * Tests for content-digest coverage per the AAuth HTTPSig profile (Section 10.3)
+ *
+ * A request carrying a body to a PS or AS endpoint MUST cover content-digest
+ * (RFC 9530). The signer covers it automatically whenever the body's exact
+ * bytes are available to hash (contentDigest: 'auto', the default), refuses
+ * to sign a non-digestible body under 'require', and leaves it off under
+ * 'omit'. The verifier enforces coverage with requireContentDigest.
+ */
+
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { fetch, verify } from '../src/index.js'
+import { generateContentDigest } from '../src/utils/signature.js'
+
+/**
+ * Generate an Ed25519 key pair as JWK
+ */
+async function generateEd25519KeyPair() {
+    const keyPair = (await crypto.subtle.generateKey(
+        {
+            name: 'Ed25519',
+        },
+        true,
+        ['sign', 'verify'],
+    )) as CryptoKeyPair
+
+    const privateJwk = await crypto.subtle.exportKey('jwk', keyPair.privateKey)
+    const publicJwk = await crypto.subtle.exportKey('jwk', keyPair.publicKey)
+
+    // alg is REQUIRED on a JWK; WebCrypto does not set it.
+    privateJwk.alg = 'Ed25519'
+    publicJwk.alg = 'Ed25519'
+
+    return { privateJwk, publicJwk }
+}
+
+test('auto: string body is covered by content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = JSON.stringify({ foo: 'bar' })
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.ok(
+        headers.get('content-digest'),
+        'content-digest header should be set',
+    )
+    assert.ok(
+        headers.get('signature-input')!.includes('"content-digest"'),
+        'signature-input should cover content-digest',
+    )
+
+    const result = await verify(
+        {
+            method: 'POST',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+            body,
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, true, 'Signature should verify')
+})
+
+test('auto: Uint8Array body is covered by content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = new TextEncoder().encode('binary payload')
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.ok(headers.get('content-digest'))
+    assert.ok(headers.get('signature-input')!.includes('"content-digest"'))
+
+    const result = await verify(
+        {
+            method: 'POST',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+            body,
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, true)
+})
+
+test('auto: ArrayBuffer body is covered by content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const bytes = new TextEncoder().encode('buffer payload')
+    const body = bytes.buffer.slice(0, bytes.byteLength) as ArrayBuffer
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.ok(headers.get('content-digest'))
+    assert.ok(headers.get('signature-input')!.includes('"content-digest"'))
+
+    const result = await verify(
+        {
+            method: 'POST',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+            body: new Uint8Array(body),
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, true)
+})
+
+test('auto: Buffer body is covered by content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = Buffer.from('node buffer payload')
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.ok(headers.get('content-digest'))
+    assert.ok(headers.get('signature-input')!.includes('"content-digest"'))
+
+    const result = await verify(
+        {
+            method: 'POST',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+            body,
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, true)
+})
+
+test('auto: ReadableStream body is signed without content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = new ReadableStream({
+        start(controller) {
+            controller.enqueue(new TextEncoder().encode('streamed'))
+            controller.close()
+        },
+    })
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.strictEqual(
+        headers.get('content-digest'),
+        null,
+        'content-digest header should not be set for a stream',
+    )
+    assert.ok(
+        !headers.get('signature-input')!.includes('content-digest'),
+        'signature-input should not cover content-digest for a stream',
+    )
+})
+
+test('auto: FormData body is signed without content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = new FormData()
+    body.append('field', 'value')
+
+    // FormData gets no content-type here (the fetch implementation generates
+    // the multipart boundary), so the default body components cannot apply.
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        components: ['@method', '@authority', '@path', 'signature-key'],
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.strictEqual(headers.get('content-digest'), null)
+    assert.ok(!headers.get('signature-input')!.includes('content-digest'))
+})
+
+test('auto: Blob body is signed without content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = new Blob(['blob payload'], { type: 'text/plain' })
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.strictEqual(headers.get('content-digest'), null)
+    assert.ok(!headers.get('signature-input')!.includes('content-digest'))
+})
+
+test('require: digestible body is covered by content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = 'payload'
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        contentDigest: 'require',
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.ok(headers.get('content-digest'))
+    assert.ok(headers.get('signature-input')!.includes('"content-digest"'))
+})
+
+test('require: non-digestible bodies throw', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const stream = new ReadableStream({
+        start(controller) {
+            controller.close()
+        },
+    })
+    const formData = new FormData()
+    formData.append('field', 'value')
+    const blob = new Blob(['blob payload'], { type: 'text/plain' })
+
+    for (const body of [stream, formData, blob]) {
+        await assert.rejects(
+            fetch('https://api.example.com/data', {
+                method: 'POST',
+                body,
+                contentDigest: 'require',
+                signingKey: privateJwk,
+                signatureKey: { type: 'hwk' },
+                dryRun: true,
+            }),
+            /cannot be digested/,
+            `${body.constructor.name} should be refused under 'require'`,
+        )
+    }
+})
+
+test('omit: string body is signed without content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = 'payload'
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        contentDigest: 'omit',
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.strictEqual(
+        headers.get('content-digest'),
+        null,
+        'omit should not add content-digest',
+    )
+    assert.ok(!headers.get('signature-input')!.includes('content-digest'))
+
+    // Pre-2.2 behavior: the signature still verifies when the verifier does
+    // not require coverage.
+    const result = await verify({
+        method: 'POST',
+        path: '/data',
+        authority: 'api.example.com',
+        headers,
+        body,
+    })
+    assert.strictEqual(result.verified, true)
+})
+
+test('omit: explicit content-digest component is still covered', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = 'payload'
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        contentDigest: 'omit',
+        components: [
+            '@method',
+            '@authority',
+            '@path',
+            'content-type',
+            'content-digest',
+            'signature-key',
+        ],
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    assert.ok(
+        headers.get('content-digest'),
+        'explicitly listed content-digest should still be generated',
+    )
+    assert.ok(headers.get('signature-input')!.includes('"content-digest"'))
+})
+
+test('generateContentDigest: hashes the four digestible types', async () => {
+    const text = 'digest me'
+    const expected = await generateContentDigest(text)
+
+    assert.match(expected, /^sha-256=:[A-Za-z0-9+/=]+:$/)
+
+    const bytes = new TextEncoder().encode(text)
+    assert.strictEqual(await generateContentDigest(bytes), expected)
+    assert.strictEqual(
+        await generateContentDigest(
+            bytes.buffer.slice(0, bytes.byteLength) as ArrayBuffer,
+        ),
+        expected,
+    )
+    assert.strictEqual(await generateContentDigest(Buffer.from(text)), expected)
+})
+
+test('generateContentDigest: throws on unhandled body types', async () => {
+    // Before 2.2.0 these fell through to String(body), producing a valid
+    // signature over the SHA-256 of literal text like
+    // "[object ReadableStream]" -- bytes that never go on the wire.
+    const stream = new ReadableStream({
+        start(controller) {
+            controller.close()
+        },
+    })
+    const formData = new FormData()
+    const blob = new Blob(['x'])
+
+    for (const body of [stream, formData, blob]) {
+        await assert.rejects(
+            generateContentDigest(body as any),
+            /Cannot generate content-digest/,
+            `${body.constructor.name} should be refused`,
+        )
+    }
+})
+
+test('requireContentDigest: fails when signature does not cover content-digest', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const body = 'payload'
+
+    // Sign without content-digest coverage
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body,
+        contentDigest: 'omit',
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    const result = await verify(
+        {
+            method: 'POST',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+            body,
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, false)
+    assert.strictEqual(result.signatureError?.error, 'invalid_input')
+    assert.ok(
+        result.signatureError?.required_input?.includes('content-digest'),
+        'required_input should name content-digest',
+    )
+})
+
+test('requireContentDigest: fails when the digest does not match the body', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'POST',
+        body: 'original body',
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    const result = await verify(
+        {
+            method: 'POST',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+            body: 'tampered body',
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, false)
+    assert.ok(
+        result.error?.includes('content-digest'),
+        'error should name content-digest',
+    )
+})
+
+test('requireContentDigest: passes on a request without a body', async () => {
+    const { privateJwk } = await generateEd25519KeyPair()
+
+    const { headers } = (await fetch('https://api.example.com/data', {
+        method: 'GET',
+        signingKey: privateJwk,
+        signatureKey: { type: 'hwk' },
+        dryRun: true,
+    })) as { headers: Headers }
+
+    const result = await verify(
+        {
+            method: 'GET',
+            path: '/data',
+            authority: 'api.example.com',
+            headers,
+        },
+        { requireContentDigest: true },
+    )
+
+    assert.strictEqual(result.verified, true)
+})


### PR DESCRIPTION
Implements the AAuth -11 Section 10.3 HTTP Message Signatures profile rule: a request carrying a body to a PS or AS endpoint MUST cover `content-digest` (RFC 9530) and `content-type` on top of the four mandatory components. Resources are exempt and declare their needs via `additional_signature_components` in resource metadata.

## Signing (`fetch()`)

- After the covered components resolve, `content-digest` is appended whenever the body's exact bytes are available to hash — `string`, `Uint8Array`, `ArrayBuffer`, `Buffer`, the four cases `generateContentDigest` handles. `ReadableStream`, `FormData`, and `Blob` are serialized by the fetch implementation, so they are not digestible here.
- `DEFAULT_COMPONENTS_BODY` is deliberately unchanged: a static list cannot know whether a given body is hashable, and adding `content-digest` there would break every streaming caller.
- New option `contentDigest?: 'auto' | 'require' | 'omit'` (default `'auto'`):
  - `'auto'` — append when digestible, sign without it otherwise
  - `'require'` — throw on a non-digestible body instead of silently dropping the component; PS and AS callers pass this
  - `'omit'` — never auto-append (pre-2.2 behavior)

## `generateContentDigest` throws on unhandled types

It previously fell through to `String(body)`, so a `ReadableStream` produced a valid signature over the SHA-256 of the literal text `"[object ReadableStream]"` — bytes that never go on the wire and that no verifier can reproduce. Without the throw, `'auto'` cannot tell "hashable" from "hashed the wrong thing".

## Verification (`verify()`)

New `VerifyOptions.requireContentDigest?: boolean`. When true, a request with a body fails verification (`invalid_input`, with `required_input` naming the full Section 10.3 body set) unless the signature covers `content-digest`; the digest itself was already validated whenever covered. This is the flag a PS or AS sets to enforce the rule instead of hand-rolling the check — the beta wallet hand-rolled exactly this.

## Tests

16 new tests in `httpsig/tests/test-content-digest.ts`: auto-append for each digestible type, no append for ReadableStream/FormData/Blob under `'auto'`, `'require'` throwing on non-digestible bodies, `'omit'` behavior (including explicit listing still working), `generateContentDigest` equivalence across the four types and throwing on unhandled ones, and `requireContentDigest` pass/fail/no-body/tampered-body on verify.

`npm test --workspace=httpsig`: 190 pass, 0 fail (174 pre-existing + 16 new). `better-auth` (32) and `email-verification` (120) suites also pass; `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQ2FCHHAnuJWF5TJB3838S